### PR TITLE
Always open in binary mode

### DIFF
--- a/lib/resty/post.lua
+++ b/lib/resty/post.lua
@@ -26,7 +26,7 @@ end
 
 local _M = new_tab(0,3)
 local mt = { __index = _M }
-_M.VERSION = '0.2.0'
+_M.VERSION = '0.2.1'
 
 local function tmp()
     return now() + random()
@@ -69,7 +69,7 @@ local function decode_disposition(self, data)
     local path = self.path
     local tmp_name = fn(name, field)
     local filename = path .. tmp_name
-    local handler = open(filename, 'w+')
+    local handler = open(filename, 'w+b')
 
     if not handler then
         log(WARN, 'failed to open file ', filename)


### PR DESCRIPTION
Without explicitly telling to open the stream in binary mode can (and probably will) corrupt uploads on Windows platform.

See also: https://github.com/openresty/lua-resty-upload/issues/25
